### PR TITLE
Update logger proxy method signature

### DIFF
--- a/Model/LoggerProxy.php
+++ b/Model/LoggerProxy.php
@@ -23,47 +23,47 @@ class LoggerProxy implements LoggerInterface
         $this->executionContext = $executionContext;
     }
 
-    public function emergency($message, array $context = array())
+    public function emergency($message, array $context = array()): void
     {
         $this->logger->emergency($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function alert($message, array $context = array())
+    public function alert($message, array $context = array()): void
     {
         $this->logger->alert($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function critical($message, array $context = array())
+    public function critical($message, array $context = array()): void
     {
         $this->logger->critical($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function error($message, array $context = array())
+    public function error($message, array $context = array()): void
     {
         $this->logger->error($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = array()): void
     {
         $this->logger->warning($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function notice($message, array $context = array())
+    public function notice($message, array $context = array()): void
     {
         $this->logger->notice($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function info($message, array $context = array())
+    public function info($message, array $context = array()): void
     {
         $this->logger->info($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = array()): void
     {
         $this->logger->debug($message, $this->executionContext->getLoggerContext($context));
     }
 
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array()): void
     {
         $this->logger->log($level, $message, $this->executionContext->getLoggerContext($context));
     }


### PR DESCRIPTION
Fix method declaration to be same as `LoggerInterface`, and remove those useless INFO from log:
```log
17:36:14 INFO      [php] User Deprecated: Method "Psr\Log\LoggerInterface::emergency()" might add "void" as a native return type declaration in the future. Do the same in implementation "Oliverde8\PhpEtlBundle\Model\LoggerProxy" now to avoid errors or add an explicit @return annotation to suppress this message.
```